### PR TITLE
Reproducible seeds on nodes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: An R package for optimization using genetic algorithms. The package
 URL: http://www.jstatsoft.org/v53/i04/
 Authors@R: c(person("Luca", "Scrucca", role = c("aut", "cre"),
                     email = "luca@stat.unipg.it"))
-Depends: R (>= 3.0), methods, foreach, iterators
+Depends: R (>= 3.0), methods, foreach, iterators, doRNG (>= 1.6)
 Imports: stats, graphics, grDevices, utils
 Suggests: parallel, doParallel, knitr (>= 1.8), markdown (>= 0.7)
 License: GPL (>= 2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
 exportPattern("^[^\\.]")
 
-import("stats", "graphics", "methods", "foreach", "iterators")
+import("stats", "graphics", "methods", "foreach", "iterators", "doRNG")
 importFrom("grDevices", "adjustcolor", "colorRampPalette")
 importFrom("utils", "str")
 

--- a/R/ga.R
+++ b/R/ga.R
@@ -141,7 +141,8 @@ ga <- function(type = c("binary", "real-valued", "permutation"),
                { Fitness[i] <- fitness(Pop[i,], ...) } 
       }
       else
-        { Fitness <- foreach(i = seq_len(popSize), .combine = "c") %dopar%
+        { if (!is.null(seed)) doRNG::registerDoRNG(as.integer(runif(1) * 1e9))
+          Fitness <- foreach(i = seq_len(popSize), .combine = "c") %dopar%
                      { if(is.na(Fitness[i])) fitness(Pop[i,], ...) 
                        else                  Fitness[i] }
         }


### PR DESCRIPTION
To implement reproducible seeds on all nodes, [the doRNG package](https://github.com/renozao/doRNG) is a great addition to `doParallel`. The changes required to GA were minimal and should have no impact on previous analysis (by my reading of the code; please let me know if I've overlooked references to a random number generator following the call to `registerDoRNG`). Please note, this patch relies on a fix to doRNG that is currently up for review (renozao/doRNG#3).

Below is a minimal example showing the fix to #2 .

```r
devtools::install_github("ElizabethAB/GA")
devtools::install_github("ElizabethAB/doRNG")

library(GA)

data("fat", package = "UsingR")
nms <- c('age', 'weight', 'height', 'neck', 'chest', 'abdomen', 'hip', 'thigh',
         'knee', 'ankle', 'bicep', 'forearm', 'wrist')

fitness <- function(string) {
  equation <- paste(c("body.fat.siri ~",
                      paste(nms[which(string == 1)], collapse = " + ")),
                    collapse = " ")
  if (equation == "body.fat.siri ~ ") return(.Machine$integer.max)
  nfold <- 10
  folds <- sample(1:nrow(fat)) %% nfold
  tmp <- sapply((1:nfold) - 1, function(fold) {
    indices <- folds %in% fold
    mod <- lm(equation, data = fat[!indices,])
    fat[indices, "body.fat.siri"] - predict(mod, fat[indices,])
  })
  -sum(unlist(tmp)^2)
}

eg <- function(par = FALSE) {
  ga("binary", fitness = fitness, nBits = length(nms), maxiter = 5,
     names = nms, monitor = NULL, seed = 20160505, parallel = par)
}

eg()@summary == eg()@summary
eg(2)@summary == eg(2)@summary
```