### PR TITLE
fix: missing population function variable args

### DIFF
--- a/R/ga.R
+++ b/R/ga.R
@@ -214,7 +214,7 @@ ga <- function(type = c("binary", "real-valued", "permutation"),
     { Pop[1:ng,] <- suggestions }
   # fill the rest with a random population
   if(popSize > ng)
-    { Pop[(ng+1):popSize,] <- population(object)[1:(popSize-ng),] }
+    { Pop[(ng+1):popSize,] <- population(object, ...)[1:(popSize-ng),] }
   object@population <- Pop
 
   # start iterations


### PR DESCRIPTION
The population function call in GA.R was not passing any further arguments to the population function although this functionality is described in the population function see screenshot:
<img width="707" height="405" alt="image" src="https://github.com/user-attachments/assets/f8b69f06-9db8-4ef2-b3af-1bc94bcee92f" />
